### PR TITLE
add osx install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,8 @@ Microsoft Malware Competition (https://www.kaggle.com/c/malware-classification)�
 
 * [Update April 21th] 新增XGBoostMalwareAnalysis(路徑：malware/)
 
- 
+* OSX El capitan installation
+    - brew tap homebrew/boneyard
+    - brew install --with-clang llvm
+    - brew install brew install gcc@5
+    - pip install xgboost


### PR DESCRIPTION
不確定你說的群集版是不是 multi-threads版
如果是的話，是因為安裝的時候缺少 clang-omp++
但是clang-omp又被brew移掉了，所以借用llvm裡面的clang
再加上原生gcc版本是6，但是xgboost 需要的是5
所以要再用 brew install gcc@5

最後就可以直接 pip install xgboost 
編譯就會過囉